### PR TITLE
Bump base linux image to 24.04 and PHP to v8.4 stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Base image from mariadb and based on Ubuntu before adding PHP
-FROM docker.io/mariadb:11-jammy
+FROM docker.io/mariadb:11-noble
 
 ### add php and apache requirements
 ENV DEBIAN_FRONTEND=noninteractive
@@ -16,18 +16,18 @@ RUN apt update && apt install -y \
         unzip
 RUN apt install -y apache2
 RUN add-apt-repository ppa:ondrej/php -y
-RUN apt install -y php8.2 \
-        php8.2-cli \
-        php8.2-fpm \
-        php8.2-gd \
-        php8.2-intl \
-        php8.2-mysql \
-        libapache2-mod-php8.2 \
-        php8.2-mbstring \
-        php8.2-xml \
-        php8.2-curl \
-        php8.2-zip \
-        php8.2-dev \
+RUN apt update && apt install -y php8.4 \
+        php8.4-cli \
+        php8.4-fpm \
+        php8.4-gd \
+        php8.4-intl \
+        php8.4-mysql \
+        libapache2-mod-php8.4 \
+        php8.4-mbstring \
+        php8.4-xml \
+        php8.4-curl \
+        php8.4-zip \
+        php8.4-dev \
         php-pear \
         pkg-config \
         libmagickwand-dev
@@ -36,18 +36,18 @@ RUN apt install -y php8.2 \
 RUN printf "\n"|pecl install imagick
 
 # Enable the PHP module and restart Apache
-RUN a2enmod php8.2
+RUN a2enmod php8.4
 RUN service apache2 restart
 
 # Optional PHP INFO to be used for checking settings (Comment out COPY if not needed)
 COPY --chown=www-data:www-data ./src/info.php /var/www/html/info.php
 # Configure PHP settings
-ENV PHP_CONF=/etc/php/8.2/apache2/php.ini
-RUN cp /usr/lib/php/8.2/php.ini-production $PHP_CONF
+ENV PHP_CONF=/etc/php/8.4/apache2/php.ini
+RUN cp /usr/lib/php/8.4/php.ini-production $PHP_CONF
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 16M/g' $PHP_CONF
 RUN sed -i 's/max_execution_time = 30/max_execution_time = 120/g' $PHP_CONF
 RUN sed -i 's/post_max_size = 8M/post_max_size = 16M/g' $PHP_CONF
-RUN sed -i 's/;extension=imap/extension=imagick\n;extension=imap/g' $PHP_CONF
+RUN sed -i 's/;extension=intl/extension=imagick\n;extension=intl/g' $PHP_CONF
 
 # Config for default apache website
 COPY ./src/apache_default /etc/apache2/sites-available/000-default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt update && apt install -y php8.4 \
         php8.4-fpm \
         php8.4-gd \
         php8.4-intl \
+        php8.4-imagick \
         php8.4-mysql \
         libapache2-mod-php8.4 \
         php8.4-mbstring \
@@ -33,7 +34,8 @@ RUN apt update && apt install -y php8.4 \
         libmagickwand-dev
 
 # Install additional IANSEO php plugins
-RUN printf "\n"|pecl install imagick
+# Commenting out pecl install as ppa:ondrej now supports imagick on php8.4
+# RUN printf "\n"|pecl install imagick
 
 # Enable the PHP module and restart Apache
 RUN a2enmod php8.4

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 ### Info:
  - Author - PJ1004
- - Version - 2.1
- - Last Modified - 26-Jan-2025
+ - Version - 2.2
+ - Last Modified - 27-Jan-2025
 
 
 ### Context:
  - Database - MariaDB:11
- - Apache Webserver - PHP 8.2
+ - Apache Webserver - PHP 8.4
  - IANSEO - 20241208
 
 ## Docker RUN
@@ -19,7 +19,7 @@
 Pull the combined ianseo php and mariadb database docker image and run as follows:
 
 ```
-docker run -dt -p 80:80 -p 3306:3306 --env-file ./.env --name ianseo pj1004/ianseo-combo:latest
+docker run -dt -p 80:80 -p 3306:3306 [--env-file ./.env] --name ianseo pj1004/ianseo-combo:latest
 ```
 
 ### Architectures
@@ -63,3 +63,10 @@ MARIADB_DATABASE=ianseo
 MARIADB_USER=ianseo
 MARIADB_PASSWORD=ianseo
 ```
+
+
+### First Run:
+When connecting to the database on the IANSEO first-run screen, just enter `localhost` in the write server Host field.  The root password is not required as a blank 'ianseo' database is created at first-time startup along with the 'ianseo' user.
+
+Refer to the .env file if you wish to change the password or database settings before first run.
+If you want to retain your customisations in the .env file for future versions, add ".env" to your ".gitignore" file

--- a/src/start.sh
+++ b/src/start.sh
@@ -27,4 +27,4 @@ if [ -z "$MARIADB_PASSWORD" ]; then
   export MARIADB_PASSWORD="ianseo"
 fi
 
-exec /usr/bin/supervisord
+exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf

--- a/src/supervisord.conf
+++ b/src/supervisord.conf
@@ -9,6 +9,7 @@ logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/superv
 pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
 nodaemon=true
+user=root
 
 ; the below section must remain in the config file for RPC
 ; (supervisorctl/web interface) to work, additional interfaces may be


### PR DESCRIPTION
Changes:
- Base MariaDB image moved from jammy to noble
- PHP upgraded from 8.2 to 8.4
- imagick install moved from pecl install to aptitude